### PR TITLE
🐞 fix: hotfix expo crash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: yarn test --maxWorkers=2 --coverage
 
   build-library:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { StyleSheet, View, Text, Button } from 'react-native';
+// @ts-ignore ts can't find module '@devvie/bottom-sheet' on github runner because it's aliased
 import BottomSheet, { type BottomSheetMethods } from '@devvie/bottom-sheet';
 
 export default function App() {

--- a/src/components/backdrop/types.d.ts
+++ b/src/components/backdrop/types.d.ts
@@ -4,7 +4,7 @@ import {
   GestureResponderEvent,
   OpaqueColorValue,
 } from 'react-native';
-import { CUSTOM_BACKDROP_POSITIONS } from '../bottomSheet';
+import { CUSTOM_BACKDROP_POSITIONS } from '../bottomSheet/types.d';
 
 export type Color =
   | string
@@ -17,7 +17,9 @@ export type BackdropProps = {
   BackdropComponent?: React.FunctionComponent<{
     _animatedHeight: Animated.Value;
   }>;
-  backdropPosition?: CUSTOM_BACKDROP_POSITIONS;
+  backdropPosition?:
+    | CUSTOM_BACKDROP_POSITIONS
+    | Lowercase<keyof typeof CUSTOM_BACKDROP_POSITIONS>;
   sheetOpen: boolean;
   containerHeight: number;
   contentContainerHeight: number;

--- a/src/components/bottomSheet/index.tsx
+++ b/src/components/bottomSheet/index.tsx
@@ -38,7 +38,7 @@ import {
   type BottomSheetMethods,
   CUSTOM_BACKDROP_POSITIONS,
   type BOTTOMSHEET,
-} from './types';
+} from './types.d';
 import useHandleAndroidBackButtonClose from '../../hooks/useHandleAndroidBackButtonClose';
 
 /**

--- a/src/components/bottomSheet/types.d.ts
+++ b/src/components/bottomSheet/types.d.ts
@@ -3,7 +3,7 @@ import {
   ANIMATIONS,
   CUSTOM_BACKDROP_POSITIONS,
   type BottomSheetMethods,
-} from '../../types';
+} from '../../types.d';
 import React from 'react';
 
 // short hand for toValue key of Animator methods
@@ -209,19 +209,21 @@ interface BottomSheetProps {
   }>;
 
   /**
-   * When `customBackdropComponent` is provided, determines its position within the sheet.\
+   * When `customBackdropComponent` is provided, determines its position within the sheet.
    *
    * **'top'** - positions the custom backdrop component directly above the sheet\
    * **'behind'** - positions the custom backdrop component behind the sheet.
-   * This is the default behaviour\
+   * This is the default behaviour
    *
    * `Note:` This prop only applies to custom backdrop component
    *
-   * `Default: 'top'`
-   * @type {"top" | "behind"}
-   * @default "behind"
+   * `Default: 'behind'`
+   * @type {"top" | "behind" | CUSTOM_BACKDROP_POSITIONS}
+   * @default "behind" / CUSTOM_BACKDROP_POSITIONS.BEHIND
    */
-  customBackdropPosition?: Lowercase<keyof typeof CUSTOM_BACKDROP_POSITIONS>;
+  customBackdropPosition?:
+    | CUSTOM_BACKDROP_POSITIONS
+    | Lowercase<keyof typeof CUSTOM_BACKDROP_POSITIONS>;
 
   /**
    * Determines whether sheet is a modal.

--- a/src/components/defaultHandleBar/index.tsx
+++ b/src/components/defaultHandleBar/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, View } from 'react-native';
-import type { DefaultHandleBarProps } from './types';
+import type { DefaultHandleBarProps } from './types.d';
 
 /**
  * This is the default handle bar component used when no custom handle bar component is provided

--- a/src/hooks/useHandleAndroidBackButtonClose/index.ts
+++ b/src/hooks/useHandleAndroidBackButtonClose/index.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { BackHandler, type NativeEventSubscription } from 'react-native';
-import type { UseHandleAndroidBackButtonClose } from './types';
+import type { UseHandleAndroidBackButtonClose } from './types.d';
 
 /**
  * Handles closing sheet for android hardware back button press event

--- a/src/hooks/useHandleKeyboardEvents/index.ts
+++ b/src/hooks/useHandleKeyboardEvents/index.ts
@@ -5,7 +5,7 @@ import {
   View,
   useWindowDimensions,
 } from 'react-native';
-import type { HeightAnimationDriver, UseHandleKeyboardEvents } from './types';
+import type { HeightAnimationDriver, UseHandleKeyboardEvents } from './types.d';
 
 /**
  * Handles keyboard pop up adjusts sheet's layout when TextInput within

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,4 @@ export {
   CUSTOM_BACKDROP_POSITIONS,
   type BottomSheetMethods,
 } from './types.d';
-export type { BottomSheetProps } from './components/bottomSheet/types';
+export type { BottomSheetProps } from './components/bottomSheet/types.d';


### PR DESCRIPTION
When example is run with expo, it crashes due to incomplete typecript declaration files (`.d.ts`)  import.

For e.g we do `import T from 'types'` instead of `import T from 'types.d'`. This works in non-expo projects, but crashes the app when run with expo.

This commit fixes #1